### PR TITLE
Fix/remove nested bvh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,9 +10,6 @@
 # Build
 cmake-build*
 
-# Editor
-.vscode
-
 # Python env
 venv
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-images
-objects

--- a/lib/hittable/hittable_list.hpp
+++ b/lib/hittable/hittable_list.hpp
@@ -30,6 +30,9 @@ struct HittableList : public Hittable {
   void loadHittables(const std::vector<std::shared_ptr<Hittable>> &_hittables) {
     hittables = _hittables;
   }
+  void clear() {
+    hittables.clear();
+  }
 
   bool hit(const Ray &ray, Hit &hit, const double minT, const double maxT) const override {
     Hit out, closest;

--- a/lib/hittable/objects/obj.hpp
+++ b/lib/hittable/objects/obj.hpp
@@ -19,6 +19,7 @@
 #include <string>
 
 struct OBJ : public Hittable {
+  HittableList hittableList;
   BVH bvh;
 
   OBJ(std::string &filepath, const std::shared_ptr<Material> &material) {
@@ -29,7 +30,7 @@ struct OBJ : public Hittable {
     }
     std::cout << "Loading object " << filepath << "\n";
 
-    HittableList objects;
+    hittableList.clear();
     for (auto &mesh : Loader.LoadedMeshes) {
       for (int i = 0; i < mesh.Indices.size(); i += 3) {
         auto a = mesh.Vertices[mesh.Indices[i]].Position;
@@ -38,11 +39,11 @@ struct OBJ : public Hittable {
         auto ap = Point3(a.X, a.Y, a.Z);
         auto bp = Point3(b.X, b.Y, b.Z);
         auto cp = Point3(c.X, c.Y, c.Z);
-        objects.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
+        hittableList.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
       }
     }
 
-    bvh = BVH(objects);
+    bvh = BVH(hittableList);
   }
 
   bool hit(const Ray &ray,

--- a/lib/hittable/objects/ply.hpp
+++ b/lib/hittable/objects/ply.hpp
@@ -3,7 +3,7 @@
 //
 
 #ifndef CPPTRACE_LIB_HITTABLE_OBJECTS_PLY_HPP_
-#define CPPTRACE_LIB_HITTABLE_OBJECTS_PLy_HPP_
+#define CPPTRACE_LIB_HITTABLE_OBJECTS_PLY_HPP_
 
 #include "../../common/vec3.hpp"
 #include "../../accelerators/bvh.hpp"
@@ -21,11 +21,11 @@
 #include <array>
 
 struct PLY : public Hittable {
+  HittableList hittableList;
   BVH bvh;
 
   PLY(const std::string &filepath, const std::shared_ptr<Material> &material) {
-    HittableList objects;
-
+    hittableList.clear();
     try {
       happly::PLYData mesh(filepath);
 
@@ -39,14 +39,14 @@ struct PLY : public Hittable {
         auto ap = Point3(a[0], a[1], a[2]);
         auto bp = Point3(b[0], b[1], b[2]);
         auto cp = Point3(c[0], c[1], c[2]);
-        objects.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
+        hittableList.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
       }
 
     } catch (std::exception &e) {
       std::cerr << e.what() << std::endl;
     }
 
-    bvh = BVH(objects);
+    bvh = BVH(hittableList);
   }
 
   bool hit(const Ray &ray,

--- a/lib/hittable/objects/stl.hpp
+++ b/lib/hittable/objects/stl.hpp
@@ -19,11 +19,11 @@
 #include <string>
 
 struct STL : public Hittable {
+  HittableList hittableList;
   BVH bvh;
 
   STL(const std::string &filepath, const std::shared_ptr<Material> &material) {
-    HittableList objects;
-
+    hittableList.clear();
     try {
       stl_reader::StlMesh<double, int> mesh(filepath);
 
@@ -34,14 +34,14 @@ struct STL : public Hittable {
         auto ap = Point3(a[0], a[1], a[2]);
         auto bp = Point3(b[0], b[1], b[2]);
         auto cp = Point3(c[0], c[1], c[2]);
-        objects.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
+        hittableList.pushHittable(std::make_shared<Triangle>(ap, bp, cp, material));
       }
 
     } catch (std::exception &e) {
       std::cerr << e.what() << std::endl;
     }
 
-    bvh = BVH(objects);
+    bvh = BVH(hittableList);
   }
 
   bool hit(const Ray &ray,

--- a/main.cpp
+++ b/main.cpp
@@ -31,7 +31,7 @@ int main() {
   auto material = std::make_shared<Lambertian>(texture);
   auto stl = std::make_shared<STL>(R"(D:\code\proj\CppTrace\objects\Ghost_Booh_N1.stl)", material);
 
-  scene.pushHittable(stl);
+  scene.pushHittables(stl->hittableList.hittables);
   scene.setAmbient(Color3(0.5, 0.5, 0.5));
 
   scene.render(24);


### PR DESCRIPTION
By removing the nested BVH calls, we reduce the overall recursion depth at runtime.