### PR TITLE
Support multiple benchmarks

### DIFF
--- a/bench.cpp
+++ b/bench.cpp
@@ -18,6 +18,20 @@
 #include <chrono>
 #include <iostream>
 #include <fstream>
+#include <vector>
+#include <map>
+
+std::vector<std::string> models = {"booh", "pickle"};
+
+std::map<std::string, Point3> origins = {
+    {"booh", Point3(0, 40, 75)},
+    {"pickle", Point3(20, 12.5, 20)},
+};
+
+std::map<std::string, double> heights = {
+    {"booh", 100},
+    {"pickle", 150},
+};
 
 struct Args {
   std::string modelpath, outputpath;
@@ -29,8 +43,8 @@ struct Args {
 Args parse(int argc, char *argv[]) {
   cmdline::parser parser;
 
-  parser.add<std::string>("modelpath", 'm', "Absolute path to model location", true);
-  parser.add<std::string>("outputpath", 'o', "Absolute path of output png", true);
+  parser.add<std::string>("modelpath", 'm', "Absolute path to model folder", true);
+  parser.add<std::string>("outputpath", 'o', "Absolute path of output folder", true);
 
   parser.parse_check(argc, argv);
 
@@ -40,20 +54,10 @@ Args parse(int argc, char *argv[]) {
   return args;
 }
 
-std::shared_ptr<Hittable> buildModel(std::string modelpath) {
-  std::string extension = modelpath.substr(modelpath.find('.'));
-  for (char &c : extension)
-    if (std::isalpha(c))
-      c = (char) std::tolower(c);
-
+std::shared_ptr<STL> buildModel(std::string modelpath) {
   std::shared_ptr<Texture> grey = std::make_shared<SolidColorTexture>(0.5, 0.5, 0.5);
   std::shared_ptr<Material> lambert = std::make_shared<Lambertian>(grey);
-
-  if (extension == ".obj") return std::make_shared<OBJ>(modelpath, lambert);
-  else if (extension == ".ply") return std::make_shared<PLY>(modelpath, lambert);
-  else if (extension == ".stl") return std::make_shared<STL>(modelpath, lambert);
-  else
-    throw std::invalid_argument("Invalid file extension '" + extension + "', only [.obj, .ply, .stl] are supported.");
+  return std::make_shared<STL>(modelpath, lambert);
 }
 
 std::string buildRenderPath(const std::string &outputpath, const ACCELERATOR &accelerator) {
@@ -63,54 +67,56 @@ std::string buildRenderPath(const std::string &outputpath, const ACCELERATOR &ac
 int main(int argc, char *argv[]) {
   auto args = parse(argc, argv);
 
-  auto object = buildModel(args.modelpath);
-  const double aspectRatio = 1;
-  const int width = 100;
-  const int height = (int) (width / aspectRatio);
-  const int samples = 1;
-  const int bounces = 1;
-  auto image = std::make_shared<Image>(args.outputpath, width, height, samples, bounces);
+  std::ofstream results(args.outputpath + "results.csv");
+  results << "triangles,accelerator,build,render\n";
 
-  Point3 origin(0, 50, 100);
-  Point3 lookAt(0, 50, 0);
-  Point3 up(0, 1, 0);
-  const double aperture = 0;
-  const double focusDist = (origin - lookAt).mag();
-  const double fov = 60;
-  auto camera = std::make_shared<Camera>(origin, lookAt, up, fov, aspectRatio, aperture,
-                                         focusDist);
+  for (const auto& model : models) {
+    auto object = buildModel(args.modelpath + model + ".stl");
 
-  std::ofstream results(args.outputpath + ".csv");
-  results << "accelerator,build,render\n";
+    const int width = 100;
+    const int height = heights[model];
+    const int samples = 1;
+    const int bounces = 1;
+    auto image = std::make_shared<Image>(args.outputpath + model + ".png", width, height, samples, bounces);
 
-  for (int acceleratorInt = KD_TREE_ACCEL; acceleratorInt <= FAST_BVH; acceleratorInt++) {
-    auto accelerator = static_cast<const ACCELERATOR>(acceleratorInt);
-    results << stringFromAccel(accelerator) << ",";
+    auto origin = origins[model];
+    Point3 lookAt(0, origin.y, 0);
+    Point3 up(0, 1, 0);
+    const double aperture = 0;
+    const double focusDist = (origin - lookAt).mag();
+    const double fov = 60;
+    auto camera = std::make_shared<Camera>(origin, lookAt, up, fov, image->aspectRatio, aperture,
+                                           focusDist);
 
-    auto renderPath = buildRenderPath(args.outputpath, accelerator);
-    image->reset(renderPath);
-    Scene scene(camera, image, accelerator);
+    for (int acceleratorInt = KD_TREE_ACCEL; acceleratorInt <= FAST_BVH; acceleratorInt++) {
+      auto accelerator = static_cast<const ACCELERATOR>(acceleratorInt);
+      results << object->numTriangles << "," << stringFromAccel(accelerator) << ",";
 
-    auto start = std::chrono::high_resolution_clock::now();
-    if (accelerator == MADMAN_BVH || accelerator == FAST_BVH) {
-      scene.loadTriangles(object->getTriangles());
-    } else {
-      scene.loadHittables(object->getHittables());
+      auto renderPath = buildRenderPath(args.outputpath + model, accelerator);
+      image->reset(renderPath);
+      Scene scene(camera, image, accelerator);
+
+      auto start = std::chrono::high_resolution_clock::now();
+      if (accelerator == MADMAN_BVH || accelerator == FAST_BVH) {
+        scene.loadTriangles(object->getTriangles());
+      } else {
+        scene.loadHittables(object->getHittables());
+      }
+      auto end = std::chrono::high_resolution_clock::now();
+      auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+      results << diff.count() << ",";
+
+      scene.setAmbient(Color3(0.5, 0.5, 0.5));
+
+      start = std::chrono::high_resolution_clock::now();
+      scene.render(1);
+      end = std::chrono::high_resolution_clock::now();
+
+      diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+      results << diff.count() << "\n";
     }
-    auto end = std::chrono::high_resolution_clock::now();
-    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    results << diff.count() << ",";
-
-    scene.setAmbient(Color3(0.5, 0.5, 0.5));
-
-    start = std::chrono::high_resolution_clock::now();
-    scene.render(1);
-    end = std::chrono::high_resolution_clock::now();
-
-    diff = std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
-    results << diff.count() << "\n";
   }
-  results.close();
 
+  results.close();
   return 0;
 }

--- a/lib/hittable/objects/stl.hpp
+++ b/lib/hittable/objects/stl.hpp
@@ -23,17 +23,19 @@ struct STL : public Hittable {
   HittableList hittableList;
   std::vector<std::shared_ptr<Triangle>> triangles;
   BVH bvh;
+  int numTriangles;
 
   STL(const std::string &filepath, const std::shared_ptr<Material> &material) {
     hittableList.clear();
     try {
       stl_reader::StlMesh<double, int> mesh(filepath);
 
+      numTriangles = (int) mesh.num_tris();
       for (int i = 0; i < mesh.num_tris(); i++) {
         const double *a = mesh.vrt_coords(mesh.tri_corner_ind(i, 0));
         const double *b = mesh.vrt_coords(mesh.tri_corner_ind(i, 1));
         const double *c = mesh.vrt_coords(mesh.tri_corner_ind(i, 2));
-        const double *n= mesh.tri_normal (i);
+        const double *n = mesh.tri_normal (i);
         auto ap = Point3(a[0], a[1], a[2]);
         auto bp = Point3(b[0], b[1], b[2]);
         auto cp = Point3(c[0], c[1], c[2]);
@@ -51,6 +53,7 @@ struct STL : public Hittable {
     } catch (std::exception &e) {
       std::cerr << e.what() << std::endl;
     }
+
 
     bvh = BVH(hittableList);
   }


### PR DESCRIPTION
Arguments for executable are now path to the directories *including* the last forward or backwards slash.

The benchmarker will grab all files and benchmark them. We are currently testing with 100k and 600k triangles

Models can be found here: https://drive.google.com/drive/folders/1SsHKw-YKaR4PmQLTe2vZGRe6nhTz6qk1?usp=share_link